### PR TITLE
update version and dependencies to close #8

### DIFF
--- a/guard-resque.gemspec
+++ b/guard-resque.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = "guard-resque"
 
-  s.add_dependency 'guard', '>= 0.8'
+  s.add_dependency 'guard', '>= 1.1'
   s.add_dependency 'resque'
 
   s.add_development_dependency 'bundler'

--- a/lib/guard/resque.rb
+++ b/lib/guard/resque.rb
@@ -73,7 +73,7 @@ module Guard
     end
 
     # Called on file(s) modifications
-    def run_on_change(paths)
+    def run_on_changes(paths)
       restart
     end
 

--- a/lib/guard/resque/version.rb
+++ b/lib/guard/resque/version.rb
@@ -1,5 +1,5 @@
 module Guard
   module ResqueVersion
-    VERSION = "0.0.5"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
I feel it makes sense to bump the minor version to separate guard-resque supported on pre-1.1 from guard resque post-1.1. In that light, I've made this a clean break to update the guard dependency to 1.1, up the version, and fix the deprecation notice.

However, if it is going to be a better choice to support both versions, I can discard this and rewrite to use the correct method per version of guard. Our code is simple enough that it might make sense to do so.
