### PR TITLE
add zeus support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,6 +50,7 @@ You can customize the resque task via the following options:
 * `vverbose`: whether to use very verbose logging (defaults to `nil`)
 * `trace`: whether to include `--trace` on the rake command (defaults to `nil`)
 * `stop_signal`: how to kill the process when restarting (defaults to `QUIT`)
+* `zeus`: run resque through zeus (defaults to `false`)
 
 
 ## Development

--- a/lib/guard/resque.rb
+++ b/lib/guard/resque.rb
@@ -21,6 +21,7 @@ module Guard
     #  - :vverbose e.g. true
     #  - :trace e.g. true
     #  - :stop_signal e.g. :QUIT or :SIGQUIT
+    #  - :zeus e.g. true
     def initialize(watchers = [], options = {})
       @options = options
       @pid = nil
@@ -28,6 +29,7 @@ module Guard
       @options[:queue] ||= DEFAULT_QUEUE
       @options[:count] ||= DEFAULT_COUNT
       @options[:task] ||= (@options[:count].to_i == 1) ? DEFAULT_TASK_SINGLE : DEFAULT_TASK_MULTIPLE
+      @options[:zeus] ||= false
       super
     end
 
@@ -85,7 +87,11 @@ module Guard
     private
 
     def cmd
-      command = ['bundle exec rake', @options[:task].to_s]
+      command = []
+      exec = @options[:zeus] ? 'zeus' : 'bundle exec'
+      command << exec
+      command << 'rake'
+      command <<  @options[:task].to_s
 
       # trace setting
       command << '--trace' if @options[:trace]

--- a/spec/guard/resque_spec.rb
+++ b/spec/guard/resque_spec.rb
@@ -47,6 +47,12 @@ describe Guard::Resque do
       obj.send(:cmd).should_not include Guard::Resque::DEFAULT_TASK_SINGLE
     end
 
+    it 'should accept :zeus option' do
+      obj = Guard::Resque.new [], :zeus => true
+      obj.send(:cmd).should include 'zeus'
+      obj.send(:cmd).should_not include 'bundle exec'
+    end
+
     it 'should provide default options' do
       obj = Guard::Resque.new []
       obj.send(:env).should include 'QUEUE' => Guard::Resque::DEFAULT_QUEUE.to_s


### PR DESCRIPTION
Run resque rake commands through zeus instead of bundle exec.  This follows roughly the same conventions used by guard-rspec for zeus support
