### PR TITLE
add load_environment option for rake to load the environment

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,7 @@ You can customize the resque task via the following options:
 * `verbose`: whether to use verbose logging (defaults to `nil`)
 * `vverbose`: whether to use very verbose logging (defaults to `nil`)
 * `trace`: whether to include `--trace` on the rake command (defaults to `nil`)
+* `load_environment`: whether to include 'environment' on the rake command (defaults to `nil`)
 * `stop_signal`: how to kill the process when restarting (defaults to `QUIT`)
 
 

--- a/lib/guard/resque.rb
+++ b/lib/guard/resque.rb
@@ -21,6 +21,7 @@ module Guard
     #  - :vverbose e.g. true
     #  - :trace e.g. true
     #  - :stop_signal e.g. :QUIT or :SIGQUIT
+    #  - :load_environment e.g. false
     def initialize(watchers = [], options = {})
       @options = options
       @pid = nil
@@ -85,7 +86,9 @@ module Guard
     private
 
     def cmd
-      command = ['bundle exec rake', @options[:task].to_s]
+      command = ['bundle exec rake']
+      command << 'environment' if @options[:load_environment]
+      command << @options[:task].to_s
 
       # trace setting
       command << '--trace' if @options[:trace]

--- a/lib/guard/resque/templates/Guardfile
+++ b/lib/guard/resque/templates/Guardfile
@@ -3,6 +3,7 @@
 #  - :task (defaults to 'resque:work' if :count is 1; 'resque:workers', otherwise)
 #  - :verbose / :vverbose (set them to anything but false to activate their respective modes)
 #  - :trace
+#  - :load_environment
 #  - :queue (defaults to "*")
 #  - :count (defaults to 1)
 #  - :environment (corresponds to RAILS_ENV for the Resque worker)

--- a/spec/guard/resque_spec.rb
+++ b/spec/guard/resque_spec.rb
@@ -39,6 +39,11 @@ describe Guard::Resque do
       obj.send(:cmd).should include '--trace'
     end
 
+    it 'should accept :load_environment option' do
+      obj = Guard::Resque.new [], :load_environment => true
+      obj.send(:cmd).should include 'environment'
+    end
+
     it 'should accept :task option' do
       task = 'environment foo'
 


### PR DESCRIPTION
There are other ways to do this but this is an easy way to support it globally.
