### PR TITLE
Update to guard 2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 pkg/*
 .rvmrc
 .rbx
+vendor/bundle/*

--- a/guard-resque.gemspec
+++ b/guard-resque.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'guard', '>= 2.0'
   s.add_dependency 'resque'
+  s.add_dependency 'guard-compat', '~> 1.1'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'

--- a/lib/guard/resque.rb
+++ b/lib/guard/resque.rb
@@ -1,5 +1,4 @@
-require 'guard'
-require 'guard/plugin'
+require 'guard/compat/plugin'
 require 'timeout'
 
 module Guard
@@ -22,13 +21,13 @@ module Guard
     #  - :trace e.g. true
     #  - :stop_signal e.g. :QUIT or :SIGQUIT
     def initialize(options = {})
+      super
       @options = options
       @pid = nil
       @stop_signal = options[:stop_signal] || DEFAULT_SIGNAL
       @options[:queue] ||= DEFAULT_QUEUE
       @options[:count] ||= DEFAULT_COUNT
       @options[:task] ||= (@options[:count].to_i == 1) ? DEFAULT_TASK_SINGLE : DEFAULT_TASK_MULTIPLE
-      super
     end
 
     def start
@@ -108,4 +107,3 @@ module Guard
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'guard/compat/test/helper'
 require 'guard/resque'
 
 ENV['GUARD_ENV'] = 'test'


### PR DESCRIPTION
I made a few changes so this plugin would work with guard 2 (see: https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0):
- Added the `guard-compat` dependency to the gemspec
- Changed the require in the Resque class to 'guard/compat/plugin' and removed old paths.
- Moved `super` to the top of `initialize`
- Added a new require to the spec_helper based on what I saw in guard-delayed (https://github.com/suranyami/guard-delayed/commit/75d42a4c4611db89700598a478af53973d2c0e1c)
- Added vendor/bundle to gitignore, purely for my benefit
